### PR TITLE
add include stddef.h

### DIFF
--- a/src/USIWire.h
+++ b/src/USIWire.h
@@ -22,6 +22,7 @@
 #ifndef USIWire_h
 #define USIWire_h
 
+#include <stddef.h>
 #include <inttypes.h>
 
 // Buffer sizes are defined in USI_TWI_Slave/USI_TWI_Slave.h


### PR DESCRIPTION
I found when I use USIWire from an Arduino Library ( a .cpp file, not the main sketch file, like a .ino file), then compiling that library, I get `USIWire.h:58:5: error: 'size_t' does not name a type
     size_t write(uint8_t)`.

So it looks like just including the "stddef.h" here in the USIWire.h header fixes this.

I use Arduino IDE 1.8.1 on MacOS. 