### PR TITLE
Add an onInterrupt callback.

### DIFF
--- a/src/USIWire.cpp
+++ b/src/USIWire.cpp
@@ -279,6 +279,11 @@ void USIWire::flush(void) {
   // XXX: to be implemented.
 }
 
+// sets function called on slave interrupt
+void USIWire::onInterrupt( void (*function)(void) ) {
+  USI_TWI_On_Slave_Interrupt = function;
+}
+
 // sets function called on slave write
 void USIWire::onReceive( void (*function)(int) ) {
   USI_TWI_On_Slave_Receive = function;

--- a/src/USIWire.h
+++ b/src/USIWire.h
@@ -62,6 +62,7 @@ class USIWire {
     int read(void);
     int peek(void);
     void flush(void);
+    void onInterrupt( void (*)(void) );
     void onReceive( void (*)(int) );
     void onRequest( void (*)(void) );
     uint8_t isActive(void);

--- a/src/USI_TWI_Slave/USI_TWI_Slave.c
+++ b/src/USI_TWI_Slave/USI_TWI_Slave.c
@@ -162,6 +162,11 @@ __interrupt void USI_Start_Condition_ISR(void)
 {
 	unsigned char tmpPin; // Temporary variable for pin state
 	unsigned char tmpRxHead; // Temporary variable to store volatile
+
+	if (USI_TWI_On_Slave_Interrupt) {
+		USI_TWI_On_Slave_Interrupt();
+	}
+
 	// call slave receive callback on repeated start
 	if (USI_TWI_On_Slave_Receive) {
 		tmpRxHead = TWI_RxHead;

--- a/src/USI_TWI_Slave/USI_TWI_Slave.h
+++ b/src/USI_TWI_Slave/USI_TWI_Slave.h
@@ -36,6 +36,7 @@ unsigned char USI_TWI_Data_In_Receive_Buffer(void);
 unsigned char USI_TWI_Space_In_Transmission_Buffer(void);
 unsigned char USI_TWI_Slave_Is_Active();
 
+void (*USI_TWI_On_Slave_Interrupt)(void);
 void (*USI_TWI_On_Slave_Transmit)(void);
 void (*USI_TWI_On_Slave_Receive)(int);
 


### PR DESCRIPTION
Add an onInterrupt() callback to allow functionality at the beginning o…f the callback e.g., turning off a watchdog. This is especially important if the ATTiny communicates with a Raspberry Pi at unorthodox clock frequencies.